### PR TITLE
Make pedingMessages.Less symmetrical.

### DIFF
--- a/demo_packet.go
+++ b/demo_packet.go
@@ -47,6 +47,9 @@ type pendingMessages []*pendingMessage
 func (ms pendingMessages) Len() int      { return len(ms) }
 func (ms pendingMessages) Swap(i, j int) { ms[i], ms[j] = ms[j], ms[i] }
 func (ms pendingMessages) Less(i, j int) bool {
+	if ms[i].tick > ms[j].tick {
+		return false
+	}
 	if ms[i].tick < ms[j].tick {
 		return true
 	}


### PR DESCRIPTION
Previously, Less(a, b) and Less(b, a) would both return true if `a.tick < b.tick && a.priority() > b.priority()`

The tick number must be the same for the priority to be checked.