### PR TITLE
Fix atoi32 for large numbers on 64 bit OSes.

### DIFF
--- a/util.go
+++ b/util.go
@@ -29,7 +29,7 @@ var (
 
 // Convert a string to an int32
 func atoi32(s string) (int32, error) {
-	n, err := strconv.Atoi(s)
+	n, err := strconv.ParseInt(s, 0, 32)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Previously it would truncate the result instead of returning an error.

Because int is 64 bits on 64 bit operating systems, strconv.Atoi will
return a 64 bit integer, which gets truncated to 32 bits without
checking to see if it fits. strconv.ParseInt takes a bit count and
verifies that the number fits before returning it.