### PR TITLE
Fix readBits losing the top few bits for unaligned reads.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -261,14 +261,14 @@ func (r *reader) readBits(n int) uint32 {
 		nBytesToRead += 1
 	}
 
-	var val uint32
+	var val uint64
 	for i := 0; i < nBytesToRead; i++ {
 		m := r.buf[(r.pos/8)+i]
-		val += (uint32(m) << uint32(i*8))
+		val += (uint64(m) << uint32(i*8))
 	}
 	val >>= uint32(bitOffset)
 	val &= ((1 << uint32(n)) - 1)
 	r.pos += n
 
-	return val
+	return uint32(val)
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -114,6 +114,18 @@ func TestReaderStrings(t *testing.T) {
 	assert.Equal("EXTRA", r.readString())
 }
 
+func TestReaderUnaligned(t *testing.T) {
+	assert := assert.New(t)
+
+	r := newReader([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
+
+	assert.Equal(uint32(0x7f), r.readBits(7))
+	assert.Equal(uint32(0xff), r.readBits(8))
+	assert.Equal(uint32(0xffff), r.readBits(16))
+	assert.Equal(uint32(0xffffffff), r.readBits(32))
+	assert.Equal(uint32(0x01), r.readBits(1))
+}
+
 func BenchmarkReadVarUint32(b *testing.B) {
 	r := newReader([]byte{0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0x8C, 0x01})
 	b.ResetTimer()


### PR DESCRIPTION
This would happen in cases where `r.pos%8 + n > 32`. A test case is included.