### PR TITLE
PE/Baseline improvements

### DIFF
--- a/class_info.go
+++ b/class_info.go
@@ -1,6 +1,8 @@
 package manta
 
-import "github.com/dotabuff/manta/dota"
+import (
+	"github.com/dotabuff/manta/dota"
+)
 
 // Internal callback for CSVCMsg_ServerInfo.
 func (p *Parser) onCSVCMsg_ServerInfo(m *dota.CSVCMsg_ServerInfo) error {

--- a/class_info.go
+++ b/class_info.go
@@ -15,7 +15,7 @@ func (p *Parser) onCDemoClassInfo(m *dota.CDemoClassInfo) error {
 	for _, c := range m.GetClasses() {
 		p.ClassInfo[c.GetClassId()] = c.GetNetworkName()
 
-		if _, ok := p.Serializers[c.GetNetworkName()]; !ok {
+		if _, ok := p.serializers[c.GetNetworkName()]; !ok {
 			_panicf("unable to find table for class %d (%s)", c.GetClassId, c.GetNetworkName())
 		}
 	}
@@ -68,12 +68,12 @@ func (p *Parser) updateInstanceBaselineItem(item *StringTableItem) {
 	}
 
 	// Create an entry in the map if needed
-	if _, ok := p.ClassBaseline[classId]; !ok {
-		p.ClassBaseline[classId] = make(map[string]interface{})
+	if _, ok := p.ClassBaselines[classId]; !ok {
+		p.ClassBaselines[classId] = NewProperties()
 	}
 
 	// Get the send table associated with the class.
-	serializer, ok := p.Serializers[className]
+	serializer, ok := p.serializers[className]
 	if !ok {
 		_panicf("unable to find send table %s for instancebaseline key %d", className, classId)
 	}
@@ -86,7 +86,7 @@ func (p *Parser) updateInstanceBaselineItem(item *StringTableItem) {
 	if len(item.Value) > 0 {
 		_debugfl(1, "Parsing entity baseline %v", serializer[0].Name)
 		r := NewReader(item.Value)
-		p.ClassBaseline[classId] = ReadProperties(r, serializer[0], nil)
+		p.ClassBaselines[classId] = ReadProperties(r, serializer[0])
 
 		// Inline test the baselines
 		if testLevel >= 1 && r.remBits() > 8 {

--- a/flattened_serializers.go
+++ b/flattened_serializers.go
@@ -262,6 +262,6 @@ func ParseSendTables(m *dota.CDemoSendTables, pst *PropertySerializerTable) *fla
 
 // Internal callback for OnCDemoSendTables.
 func (p *Parser) onCDemoSendTables(m *dota.CDemoSendTables) error {
-	p.Serializers = ParseSendTables(m, GetDefaultPropertySerializerTable()).Serializers
+	p.serializers = ParseSendTables(m, GetDefaultPropertySerializerTable()).Serializers
 	return nil
 }

--- a/manta_test.go
+++ b/manta_test.go
@@ -19,6 +19,19 @@ func TestParseOneMatch(t *testing.T) {
 	assert.Nil(err)
 }
 
+func TestParseOneMatchWithoutPE(t *testing.T) {
+	assert := assert.New(t)
+	debugLevel = 0
+	testLevel = 0
+
+	buf := mustGetReplayData("1731962898", "https://s3-us-west-2.amazonaws.com/manta.dotabuff/1731962898.dem")
+	parser, err := NewParser(buf)
+	parser.ProcessPacketEntities = false
+	assert.Nil(err)
+	err = parser.Start()
+	assert.Nil(err)
+}
+
 // Simply tests that we can read the outer structure of a real match
 func TestParseRealMatches(t *testing.T) {
 	assert := assert.New(t)

--- a/packet_entity.go
+++ b/packet_entity.go
@@ -5,12 +5,26 @@ import (
 )
 
 // Represents the state of an entity
-type packetEntity struct {
-	index      int32
-	classId    int32
-	className  string
-	flatTbl    *dt
-	properties map[string]interface{}
+type PacketEntity struct {
+	Index         int32
+	ClassId       int32
+	ClassName     string
+	ClassBaseline *Properties
+	Properties    *Properties
+	Serial        int32
+
+	flatTbl *dt
+}
+
+// Get a property from the entity. Prefers reading from the entity properties,
+// falling back to the baseline properties if necessary.
+func (pe *PacketEntity) Fetch(key string) (interface{}, bool) {
+	v, ok := pe.Properties.Fetch(key)
+	if !ok {
+		v, ok = pe.ClassBaseline.Fetch(key)
+	}
+
+	return v, ok
 }
 
 // Internal callback for CSVCMsg_PacketEntities.
@@ -53,54 +67,51 @@ func (p *Parser) onCSVCMsg_PacketEntities(m *dota.CSVCMsg_PacketEntities) error 
 		// Proceed based on the update type
 		switch updateType {
 		case "C":
-			// Create a new packetEntity.
-			pe := &packetEntity{
-				index:      index,
-				classId:    int32(r.readBits(p.classIdSize)),
-				properties: make(map[string]interface{}),
+			// Create a new PacketEntity.
+			pe := &PacketEntity{
+				Index:      index,
+				ClassId:    int32(r.readBits(p.classIdSize)),
+				Serial:     int32(r.readBits(25)),
+				Properties: NewProperties(),
 			}
 
-			// Skip the 10 serial bits for now.
-			serial := r.readBits(25)
-			_debugfl(5, "Read serial: %v", serial)
+			// Get the associated class
+			if pe.ClassName, ok = p.ClassInfo[pe.ClassId]; !ok {
+				_panicf("unable to find class %d", pe.ClassId)
+			}
 
-			// Get the associated class.
-			if pe.className, ok = p.ClassInfo[pe.classId]; !ok {
-				_panicf("unable to find class %d", pe.classId)
+			// Get the associated baseline
+			if pe.ClassBaseline, ok = p.ClassBaselines[pe.ClassId]; !ok {
+				_panicf("unable to find class baseline %d", pe.ClassId)
 			}
 
 			// Get the associated serializer
-			if pe.flatTbl, ok = p.Serializers[pe.className][0]; !ok {
-				_panicf("unable to find serializer for class %s", pe.className)
+			if pe.flatTbl, ok = p.serializers[pe.ClassName][0]; !ok {
+				_panicf("unable to find serializer for class %s", pe.ClassName)
 			}
 
 			// Register the packetEntity with the parser.
-			p.packetEntities[index] = pe
+			p.PacketEntities[index] = pe
 
-			// Read properties, copy over the baseline if any
-			if _, ok := p.ClassBaseline[pe.classId]; ok {
-				pe.properties = ReadProperties(r, pe.flatTbl, p.ClassBaseline[pe.classId])
-			} else {
-				pe.properties = ReadProperties(r, pe.flatTbl, nil)
-			}
+			// Read properties
+			pe.Properties = ReadProperties(r, pe.flatTbl)
+
 		case "U":
 			// Find the existing packetEntity
-			pe, ok := p.packetEntities[index]
+			pe, ok := p.PacketEntities[index]
 			if !ok {
-				_debugf("unable to find packet entity %d for update", index)
+				_panicf("unable to find packet entity %d for update", index)
 			}
 
 			// Read properties and update the packetEntity
-			for k, v := range ReadProperties(r, pe.flatTbl, nil) {
-				pe.properties[k] = v
-			}
+			pe.Properties.Merge(ReadProperties(r, pe.flatTbl))
 
 		case "D":
-			if _, ok := p.packetEntities[index]; !ok {
+			if _, ok := p.PacketEntities[index]; !ok {
 				_panicf("unable to find packet entity %d for delete", index)
-			} else {
-				delete(p.packetEntities, index)
 			}
+
+			delete(p.PacketEntities, index)
 		}
 	}
 

--- a/packet_entity.go
+++ b/packet_entity.go
@@ -29,6 +29,10 @@ func (pe *PacketEntity) Fetch(key string) (interface{}, bool) {
 
 // Internal callback for CSVCMsg_PacketEntities.
 func (p *Parser) onCSVCMsg_PacketEntities(m *dota.CSVCMsg_PacketEntities) error {
+	if !p.ProcessPacketEntities {
+		return nil
+	}
+
 	_debugfl(5, "pTick=%d isDelta=%v deltaFrom=%d updatedEntries=%d maxEntries=%d baseline=%d updateBaseline=%v", p.Tick, m.GetIsDelta(), m.GetDeltaFrom(), m.GetUpdatedEntries(), m.GetMaxEntries(), m.GetBaseline(), m.GetUpdateBaseline())
 
 	r := NewReader(m.GetEntityData())

--- a/parser.go
+++ b/parser.go
@@ -24,17 +24,18 @@ type Parser struct {
 	// Contains the net tick associated with the last net message processed.
 	NetTick uint32
 
-	hasClassInfo      bool
-	ClassInfo         map[int32]string
+	ClassBaselines map[int32]*Properties
+	ClassInfo      map[int32]string
+	PacketEntities map[int32]*PacketEntity
+	StringTables   *StringTables
+
 	classIdSize       int
-	ClassBaseline     map[int32]map[string]interface{}
-	packetEntities    map[int32]*packetEntity
-	StringTables      *StringTables
-	Serializers       map[string]map[int32]*dt
-	spawnGroups       map[uint32]*spawnGroup
+	gameEventHandlers map[string][]gameEventHandler
 	gameEventNames    map[int32]string
 	gameEventTypes    map[string]*gameEventType
-	gameEventHandlers map[string][]gameEventHandler
+	hasClassInfo      bool
+	serializers       map[string]map[int32]*dt
+	spawnGroups       map[uint32]*spawnGroup
 
 	reader            *Reader
 	isStopping        bool
@@ -56,21 +57,21 @@ func NewParser(buf []byte) (*Parser, error) {
 	// Create a new parser with an internal reader for the given buffer.
 	parser := &Parser{
 		Callbacks: &Callbacks{},
+		Tick:      0,
+		NetTick:   0,
 
-		Tick:    0,
-		NetTick: 0,
+		ClassBaselines: make(map[int32]*Properties),
+		ClassInfo:      make(map[int32]string),
+		PacketEntities: make(map[int32]*PacketEntity),
+		StringTables:   newStringTables(),
+
+		gameEventHandlers: make(map[string][]gameEventHandler),
+		gameEventNames:    make(map[int32]string),
+		gameEventTypes:    make(map[string]*gameEventType),
+		spawnGroups:       make(map[uint32]*spawnGroup),
 
 		reader:     NewReader(buf),
 		isStopping: false,
-
-		ClassInfo:         make(map[int32]string),
-		ClassBaseline:     make(map[int32]map[string]interface{}),
-		packetEntities:    make(map[int32]*packetEntity),
-		StringTables:      newStringTables(),
-		spawnGroups:       make(map[uint32]*spawnGroup),
-		gameEventNames:    make(map[int32]string),
-		gameEventTypes:    make(map[string]*gameEventType),
-		gameEventHandlers: make(map[string][]gameEventHandler),
 	}
 
 	// Parse out the header, ensuring that it's valid.

--- a/parser.go
+++ b/parser.go
@@ -24,6 +24,9 @@ type Parser struct {
 	// Contains the net tick associated with the last net message processed.
 	NetTick uint32
 
+	// Determines whether or not PacketEntity events are processed.
+	ProcessPacketEntities bool
+
 	ClassBaselines map[int32]*Properties
 	ClassInfo      map[int32]string
 	PacketEntities map[int32]*PacketEntity
@@ -59,6 +62,8 @@ func NewParser(buf []byte) (*Parser, error) {
 		Callbacks: &Callbacks{},
 		Tick:      0,
 		NetTick:   0,
+
+		ProcessPacketEntities: true,
 
 		ClassBaselines: make(map[int32]*Properties),
 		ClassInfo:      make(map[int32]string),

--- a/property.go
+++ b/property.go
@@ -8,22 +8,27 @@ func init() {
 	}
 }
 
+// Properties is an instance of a set of properties containing key-value data.
 type Properties struct {
 	KV map[string]interface{}
 }
 
+// Creates a new instance of Properties.
 func NewProperties() *Properties {
 	return &Properties{
 		KV: map[string]interface{}{},
 	}
 }
 
+// Merge another set of Properties into an existing instance. Values from the
+// other (merging) set overwrite those in the existing instance.
 func (p *Properties) Merge(p2 *Properties) {
 	for k, v := range p2.KV {
 		p.KV[k] = v
 	}
 }
 
+// Fetch a value by key.
 func (p *Properties) Fetch(k string) (interface{}, bool) {
 	v, ok := p.KV[k]
 	return v, ok
@@ -42,6 +47,8 @@ func ReadProperties(r *Reader, ser *dt) (result *Properties) {
 
 	// iterate all the fields and set their corresponding values
 	for _, f := range fieldPath.fields {
+		_debugfl(6, "Decoding field %d %s %s", r.pos, f.Name, f.Field.Type)
+
 		if f.Field.Serializer.Decode == nil {
 			result.KV[f.Name] = r.readVarUint32()
 			_debugfl(6, "Decoded default: %d %s %s %v", r.pos, f.Name, f.Field.Type, result.KV[f.Name])
@@ -57,44 +64,5 @@ func ReadProperties(r *Reader, ser *dt) (result *Properties) {
 		_debugfl(6, "Decoded: %d %s %s %v", r.pos, f.Name, f.Field.Type, result.KV[f.Name])
 	}
 
-	return result
-}
-
-// An ordered map
-type omap struct {
-	size   int
-	keys   []string
-	values []interface{}
-}
-
-// Creates a new ordered map.
-func newOmap() *omap {
-	return &omap{
-		size:   0,
-		keys:   []string{},
-		values: []interface{}{},
-	}
-}
-
-// Adds an element to the ordered map.
-func (o *omap) add(k string, v interface{}) {
-	o.keys = append(o.keys, k)
-	o.values = append(o.values, v)
-	o.size++
-}
-
-// Prints the ordered map, in order.
-func (o *omap) print() {
-	for i := 0; i < o.size; i++ {
-		_debugf("[%d] %s = %v", i, o.keys[i], o.values[i])
-	}
-}
-
-// Converts the ordered map to map[string]interface{}
-func (o *omap) toMap() map[string]interface{} {
-	result := make(map[string]interface{})
-	for i := 0; i < o.size; i++ {
-		result[o.keys[i]] = o.values[i]
-	}
 	return result
 }

--- a/property_test.go
+++ b/property_test.go
@@ -299,11 +299,12 @@ func TestReadProperties(t *testing.T) {
 
 		// Read properties
 		r := NewReader(buf)
-		props := ReadProperties(r, serializer, nil)
-		assert.Equal(s.expectCount, len(props))
+		props := ReadProperties(r, serializer)
+		assert.Equal(s.expectCount, len(props.KV))
 
 		for k, v := range s.expectKeys {
-			assert.EqualValues(v, props[k])
+			got, _ := props.Fetch(k)
+			assert.EqualValues(v, got)
 		}
 
 		// There shouldn't be more than 8 bits left in the buffer


### PR DESCRIPTION
This exports PacketEntities, improves performance by re-using pointers to existing baseline properties, and has some general cleanup.

Improves real-world performance by about 22%.

Changes:

- Export Parser PacketEntities
- Clean up Parser exports
- Extract property KV to an object
- Don't re-read baseline on every entity creation, reference the baseline Properties instead.
- Add flag to skip processing PE's (for benchmarking and simple use cases)