### PR TITLE
More PE improvements

### DIFF
--- a/manta_test.go
+++ b/manta_test.go
@@ -15,6 +15,11 @@ func TestParseOneMatch(t *testing.T) {
 	buf := mustGetReplayData("1731962898", "https://s3-us-west-2.amazonaws.com/manta.dotabuff/1731962898.dem")
 	parser, err := NewParser(buf)
 	assert.Nil(err)
+
+	parser.OnPacketEntity(func(pe *PacketEntity, e EntityEventType) error {
+		return nil
+	})
+
 	err = parser.Start()
 	assert.Nil(err)
 }

--- a/parser.go
+++ b/parser.go
@@ -32,13 +32,15 @@ type Parser struct {
 	PacketEntities map[int32]*PacketEntity
 	StringTables   *StringTables
 
-	classIdSize       int
-	gameEventHandlers map[string][]gameEventHandler
-	gameEventNames    map[int32]string
-	gameEventTypes    map[string]*gameEventType
-	hasClassInfo      bool
-	serializers       map[string]map[int32]*dt
-	spawnGroups       map[uint32]*spawnGroup
+	classIdSize             int
+	gameEventHandlers       map[string][]gameEventHandler
+	gameEventNames          map[int32]string
+	gameEventTypes          map[string]*gameEventType
+	hasClassInfo            bool
+	packetEntityHandlers    []packetEntityHandler
+	packetEntityFullPackets int
+	serializers             map[string]map[int32]*dt
+	spawnGroups             map[uint32]*spawnGroup
 
 	reader            *Reader
 	isStopping        bool
@@ -70,10 +72,11 @@ func NewParser(buf []byte) (*Parser, error) {
 		PacketEntities: make(map[int32]*PacketEntity),
 		StringTables:   newStringTables(),
 
-		gameEventHandlers: make(map[string][]gameEventHandler),
-		gameEventNames:    make(map[int32]string),
-		gameEventTypes:    make(map[string]*gameEventType),
-		spawnGroups:       make(map[uint32]*spawnGroup),
+		gameEventHandlers:    make(map[string][]gameEventHandler),
+		gameEventNames:       make(map[int32]string),
+		gameEventTypes:       make(map[string]*gameEventType),
+		packetEntityHandlers: make([]packetEntityHandler, 0),
+		spawnGroups:          make(map[uint32]*spawnGroup),
 
 		reader:     NewReader(buf),
 		isStopping: false,


### PR DESCRIPTION
- Add callbacks for PE events
- Skip full packets after the first (data is already in deltas)
- Improve performance of PE create events on existing entities

Enables new functionality and shows a 5-12% reduction in parse times for real workloads.