### PR TITLE
Patch for 2016-17-27

### DIFF
--- a/fieldpath.go
+++ b/fieldpath.go
@@ -153,7 +153,7 @@ func (fp *fieldpath) addField() {
 			// If this panics, the property in question migh have a type that doesn't premit automatic array deduction (e.g. no CUtlVector prefix, or [] suffix).
 			// Adjust the type manualy in property_serializers.go
 
-			_panicf("expected table in fp properties: %v, %v", cDt.Properties[fp.index[i]].Field.Name, cDt.Properties[fp.index[i]].Field.Type)
+			_panicf("expected table for type %s fp properties: %v, %v", cDt.Name, cDt.Properties[fp.index[i]].Field.Name, cDt.Properties[fp.index[i]].Field.Type)
 		}
 	}
 

--- a/manta_test.go
+++ b/manta_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMatch2109130988(t *testing.T) { testScenarios[2109130988].test(t) }
+
 func TestMatch1855408730(t *testing.T) { testScenarios[1855408730].test(t) }
 func TestMatch1855345768(t *testing.T) { testScenarios[1855345768].test(t) }
 func TestMatch1855304265(t *testing.T) { testScenarios[1855304265].test(t) }
@@ -51,6 +53,18 @@ type testScenario struct {
 }
 
 var testScenarios = map[int64]testScenario{
+	2109130988: {
+		matchId:                "2109130988",
+		replayUrl:              "https://s3-us-west-2.amazonaws.com/manta.dotabuff/2109130988.dem",
+		debugLevel:             10,
+		expectGameBuild:        1234,
+		expectEntityEvents:     0,
+		expectCombatLogDamage:  0,
+		expectCombatLogHealing: 0,
+		expectCombatLogDeaths:  0,
+		expectCombatLogEvents:  0,
+		expectUnitOrderEvents:  34862,
+	},
 	1855408730: {
 		matchId:                "1855408730",
 		replayUrl:              "https://s3-us-west-2.amazonaws.com/manta.dotabuff/1855408730.dem",

--- a/manta_test.go
+++ b/manta_test.go
@@ -58,15 +58,15 @@ var testScenarios = map[int64]testScenario{
 	2109130988: {
 		matchId:                "2109130988",
 		replayUrl:              "https://s3-us-west-2.amazonaws.com/manta.dotabuff/2109130988.dem",
-		debugLevel:             10,
-		expectGameBuild:        1234,
-		expectEntityEvents:     0,
+		expectGameBuild:        1253,
+		expectEntityEvents:     1072803,
 		expectCombatLogDamage:  0,
 		expectCombatLogHealing: 0,
 		expectCombatLogDeaths:  0,
 		expectCombatLogEvents:  0,
-		expectUnitOrderEvents:  34862,
+		expectUnitOrderEvents:  40297,
 	},
+
 	1855408730: {
 		matchId:                "1855408730",
 		replayUrl:              "https://s3-us-west-2.amazonaws.com/manta.dotabuff/1855408730.dem",

--- a/property_serializers.go
+++ b/property_serializers.go
@@ -236,16 +236,14 @@ func (pst *PropertySerializerTable) GetPropertySerializerByName(name string) *Pr
 		return ps
 	}
 
-	if name == "DOTA_PlayerChallengeInfo" {
-		typeName := "DOTA_PlayerChallengeInfo"
-
+	if name == "DOTA_PlayerChallengeInfo" || name == "DOTA_CombatLogQueryProgress" {
 		ps := &PropertySerializer{
 			Decode:          decoder,
 			DecodeContainer: decoderContainer,
 			IsArray:         true,
 			Length:          uint32(30),
 			ArraySerializer: nil,
-			Name:            typeName,
+			Name:            name,
 		}
 
 		pst.Serializers[name] = ps


### PR DESCRIPTION
Manta doesn't automatically handle unknown array types as well as it should. This is a temporary fix for the Winter 2016 Battle Pass.