### PR TITLE
More perf improvements, cleanup

### DIFF
--- a/class_info.go
+++ b/class_info.go
@@ -58,7 +58,9 @@ func (p *Parser) updateInstanceBaseline() {
 
 	stringTable, ok := p.StringTables.GetTableByName("instancebaseline")
 	if !ok {
-		_debugf("skipping updateInstanceBaseline: no instancebaseline string table")
+		if v(1) {
+			_debugf("skipping updateInstanceBaseline: no instancebaseline string table")
+		}
 		return
 	}
 
@@ -98,13 +100,10 @@ func (p *Parser) updateInstanceBaselineItem(item *StringTableItem) {
 	// Parse the properties out of the string table buffer and store
 	// them as the class baseline in the Parser.
 	if len(item.Value) > 0 {
-		_debugfl(1, "Parsing entity baseline %v", serializer[0].Name)
+		if v(1) {
+			_debugf("parsing entity baseline %v", serializer[0].Name)
+		}
 		r := NewReader(item.Value)
 		p.ClassBaselines[classId].readProperties(r, serializer[0])
-
-		// Inline test the baselines
-		if testLevel >= 1 && r.remBits() > 8 {
-			_panicf("Too many bits remaining in baseline %v, %v", serializer[0].Name, r.remBits())
-		}
 	}
 }

--- a/fieldpath.go
+++ b/fieldpath.go
@@ -118,13 +118,12 @@ func (fp *fieldpath) addField() {
 	var name string
 	var i int
 
-	if debugLevel >= 6 {
+	if v(6) {
 		var path string
 		for i := 0; i < len(fp.index)-1; i++ {
 			path += strconv.Itoa(int(fp.index[i])) + "/"
 		}
-
-		_debugfl(6, "Adding field with path: %s%d", path, fp.index[len(fp.index)-1])
+		_debugf("adding field with path: %s%d", path, fp.index[len(fp.index)-1])
 	}
 
 	for i = 0; i < len(fp.index)-1; i++ {
@@ -158,146 +157,104 @@ func newFieldpathHuffman() HuffmanTree {
 // All different fieldops below
 
 func PlusOne(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += 1
 }
 
 func PlusTwo(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += 2
 }
 
 func PlusThree(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += 3
 }
 
 func PlusFour(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += 4
 }
 
 func PlusN(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += int32(r.readUBitVarFP()) + 5
 }
 
 func PushOneLeftDeltaZeroRightZero(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = append(fp.index, 0)
 }
 
 func PushOneLeftDeltaZeroRightNonZero(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 }
 
 func PushOneLeftDeltaOneRightZero(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += 1
 	fp.index = append(fp.index, 0)
 }
 
 func PushOneLeftDeltaOneRightNonZero(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += 1
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 }
 
 func PushOneLeftDeltaNRightZero(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += int32(r.readUBitVarFP())
 	fp.index = append(fp.index, 0)
 }
 
 func PushOneLeftDeltaNRightNonZero(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += int32(r.readUBitVarFP()) + 2
 	fp.index = append(fp.index, int32(r.readUBitVarFP())+1)
 }
 
 func PushOneLeftDeltaNRightNonZeroPack6Bits(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += int32(r.readBits(3)) + 2
 	fp.index = append(fp.index, int32(r.readBits(3))+1)
 }
 
 func PushOneLeftDeltaNRightNonZeroPack8Bits(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += int32(r.readBits(4)) + 2
 	fp.index = append(fp.index, int32(r.readBits(4))+1)
 }
 
 func PushTwoLeftDeltaZero(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 }
 
 func PushTwoLeftDeltaOne(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1]++
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 }
 
 func PushTwoLeftDeltaN(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += int32(r.readUBitVar()) + 2
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 }
 
 func PushTwoPack5LeftDeltaZero(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = append(fp.index, int32(r.readBits(5)))
 	fp.index = append(fp.index, int32(r.readBits(5)))
 }
 
 func PushTwoPack5LeftDeltaOne(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1]++
 	fp.index = append(fp.index, int32(r.readBits(5)))
 	fp.index = append(fp.index, int32(r.readBits(5)))
 }
 
 func PushTwoPack5LeftDeltaN(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += int32(r.readUBitVar()) + 2
 	fp.index = append(fp.index, int32(r.readBits(5)))
 	fp.index = append(fp.index, int32(r.readBits(5)))
 }
 
 func PushThreeLeftDeltaZero(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 }
 
 func PushThreeLeftDeltaOne(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1]++
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
@@ -305,8 +262,6 @@ func PushThreeLeftDeltaOne(r *Reader, fp *fieldpath) {
 }
 
 func PushThreeLeftDeltaN(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += int32(r.readUBitVar()) + 2
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
 	fp.index = append(fp.index, int32(r.readUBitVarFP()))
@@ -314,16 +269,12 @@ func PushThreeLeftDeltaN(r *Reader, fp *fieldpath) {
 }
 
 func PushThreePack5LeftDeltaZero(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = append(fp.index, int32(r.readBits(5)))
 	fp.index = append(fp.index, int32(r.readBits(5)))
 	fp.index = append(fp.index, int32(r.readBits(5)))
 }
 
 func PushThreePack5LeftDeltaOne(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1]++
 	fp.index = append(fp.index, int32(r.readBits(5)))
 	fp.index = append(fp.index, int32(r.readBits(5)))
@@ -331,8 +282,6 @@ func PushThreePack5LeftDeltaOne(r *Reader, fp *fieldpath) {
 }
 
 func PushThreePack5LeftDeltaN(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-1] += int32(r.readUBitVar()) + 2
 	fp.index = append(fp.index, int32(r.readBits(5)))
 	fp.index = append(fp.index, int32(r.readBits(5)))
@@ -340,8 +289,6 @@ func PushThreePack5LeftDeltaN(r *Reader, fp *fieldpath) {
 }
 
 func PushN(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	n := int(r.readUBitVar())
 	fp.index[len(fp.index)-1] += int32(r.readUBitVar())
 
@@ -351,8 +298,6 @@ func PushN(r *Reader, fp *fieldpath) {
 }
 
 func PushNAndNonTopological(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	for i := 0; i < len(fp.index); i++ {
 		if r.readBoolean() {
 			fp.index[i] += r.readVarInt32() + 1
@@ -366,29 +311,21 @@ func PushNAndNonTopological(r *Reader, fp *fieldpath) {
 }
 
 func PopOnePlusOne(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = fp.index[:len(fp.index)-1]
 	fp.index[len(fp.index)-1] += 1
 }
 
 func PopOnePlusN(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = fp.index[:len(fp.index)-1]
 	fp.index[len(fp.index)-1] += int32(r.readUBitVarFP()) + 1
 }
 
 func PopAllButOnePlusOne(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = fp.index[:1]
 	fp.index[len(fp.index)-1] += 1
 }
 
 func PopAllButOnePlusN(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = fp.index[:1]
 	fp.index[len(fp.index)-1] += int32(r.readUBitVarFP()) + 1
 }
@@ -398,36 +335,26 @@ func PopAllButOnePlusNPackN(r *Reader, fp *fieldpath) {
 }
 
 func PopAllButOnePlusNPack3Bits(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = fp.index[:1]
 	fp.index[len(fp.index)-1] += int32(r.readBits(3)) + 1
 }
 
 func PopAllButOnePlusNPack6Bits(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = fp.index[:1]
 	fp.index[len(fp.index)-1] += int32(r.readBits(6)) + 1
 }
 
 func PopNPlusOne(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = fp.index[:len(fp.index)-(int(r.readUBitVarFP()))]
 	fp.index[len(fp.index)-1] += 1
 }
 
 func PopNPlusN(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = fp.index[:len(fp.index)-(int(r.readUBitVarFP()))]
 	fp.index[len(fp.index)-1] += r.readVarInt32()
 }
 
 func PopNAndNonTopographical(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index = fp.index[:len(fp.index)-(int(r.readUBitVarFP()))]
 
 	for i := 0; i < len(fp.index); i++ {
@@ -438,8 +365,6 @@ func PopNAndNonTopographical(r *Reader, fp *fieldpath) {
 }
 
 func NonTopoComplex(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	for i := 0; i < len(fp.index); i++ {
 		if r.readBoolean() {
 			fp.index[i] += r.readVarInt32()
@@ -448,14 +373,10 @@ func NonTopoComplex(r *Reader, fp *fieldpath) {
 }
 
 func NonTopoPenultimatePlusOne(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.index[len(fp.index)-2] += 1
 }
 
 func NonTopoComplexPack4Bits(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	for i := 0; i < len(fp.index); i++ {
 		if r.readBoolean() {
 			fp.index[i] += int32(r.readBits(4)) - 7
@@ -464,7 +385,5 @@ func NonTopoComplexPack4Bits(r *Reader, fp *fieldpath) {
 }
 
 func FieldPathEncodeFinish(r *Reader, fp *fieldpath) {
-	_debugfl(10, "Name: %s", fp.parent.Name)
-
 	fp.finished = true
 }

--- a/fieldpath_test.go
+++ b/fieldpath_test.go
@@ -84,9 +84,6 @@ func TestFieldpath(t *testing.T) {
 	p := &Parser{}
 	fs := p.ParseSendTables(m, GetDefaultPropertySerializerTable())
 
-	//printCodes(huf, []byte{})
-	//_debugf("%s", fs.dump_json("CSpeechBubbleManager"))
-
 	// Iterate over the different scenarios
 	// -! Create a new FieldPath for each scenario
 	for _, s := range scenarios {
@@ -103,9 +100,6 @@ func TestFieldpath(t *testing.T) {
 		if !s.run {
 			continue
 		}
-
-		// Set debug status
-		debugMode = s.debug
 
 		// Initialize a field path and walk it
 		fieldPath := newFieldpath(serializer)

--- a/fieldpath_test.go
+++ b/fieldpath_test.go
@@ -84,9 +84,6 @@ func TestFieldpath(t *testing.T) {
 	p := &Parser{}
 	fs := p.ParseSendTables(m, GetDefaultPropertySerializerTable())
 
-	// Build the huffman tree
-	huf := newFieldpathHuffman()
-
 	//printCodes(huf, []byte{})
 	//_debugf("%s", fs.dump_json("CSpeechBubbleManager"))
 
@@ -111,7 +108,7 @@ func TestFieldpath(t *testing.T) {
 		debugMode = s.debug
 
 		// Initialize a field path and walk it
-		fieldPath := newFieldpath(serializer, &huf)
+		fieldPath := newFieldpath(serializer)
 		fieldPath.walk(NewReader(buf))
 
 		// Verify field count

--- a/game_event.go
+++ b/game_event.go
@@ -207,7 +207,6 @@ func (p *Parser) onCMsgSource1LegacyGameEventList(m *dota.CMsgSource1LegacyGameE
 		}
 		p.gameEventNames[d.GetEventid()] = d.GetName()
 		p.gameEventTypes[d.GetName()] = t
-		_debugf("registering game event type %s: %v", d.GetName(), t)
 	}
 
 	return nil

--- a/gen/message_lookup.go
+++ b/gen/message_lookup.go
@@ -256,7 +256,9 @@ func (p *Parser) %s(t int32, raw []byte) (error) {
   %s
   }
 
-  _debugf("warning: no type %%d found", t)
+  if v(1) {
+	  _debugf("warning: no type %%d found", t)
+	}
 
   return nil
 }

--- a/huffman.go
+++ b/huffman.go
@@ -110,7 +110,7 @@ func (th treeHeap) Swap(i, j int) {
 }
 
 // Construct a tree from a map of weight -> item
-func buildTree(symFreqs []int) HuffmanTree {
+func buildHuffmanTree(symFreqs []int) HuffmanTree {
 	var trees treeHeap
 	for v, w := range symFreqs {
 		if w == 0 {

--- a/message_lookup.go
+++ b/message_lookup.go
@@ -1181,7 +1181,9 @@ func (p *Parser) CallByDemoType(t int32, raw []byte) error {
 		return nil
 	}
 
-	_debugf("warning: no type %d found", t)
+	if v(1) {
+		_debugf("warning: no type %d found", t)
+	}
 
 	return nil
 }
@@ -3492,7 +3494,9 @@ func (p *Parser) CallByPacketType(t int32, raw []byte) error {
 		return nil
 	}
 
-	_debugf("warning: no type %d found", t)
+	if v(1) {
+		_debugf("warning: no type %d found", t)
+	}
 
 	return nil
 }

--- a/packet_entity.go
+++ b/packet_entity.go
@@ -106,7 +106,9 @@ func (p *Parser) onCSVCMsg_PacketEntities(m *dota.CSVCMsg_PacketEntities) error 
 		return nil
 	}
 
-	_debugfl(5, "pTick=%d isDelta=%v deltaFrom=%d updatedEntries=%d maxEntries=%d baseline=%d updateBaseline=%v", p.Tick, m.GetIsDelta(), m.GetDeltaFrom(), m.GetUpdatedEntries(), m.GetMaxEntries(), m.GetBaseline(), m.GetUpdateBaseline())
+	if v(5) {
+		_debugf("pTick=%d isDelta=%v deltaFrom=%d updatedEntries=%d maxEntries=%d baseline=%d updateBaseline=%v", p.Tick, m.GetIsDelta(), m.GetDeltaFrom(), m.GetUpdatedEntries(), m.GetMaxEntries(), m.GetBaseline(), m.GetUpdateBaseline())
+	}
 
 	// Skip processing full updates after the first. We'll process deltas instead.
 	if !m.GetIsDelta() && p.packetEntityFullPackets > 0 {
@@ -127,7 +129,6 @@ func (p *Parser) onCSVCMsg_PacketEntities(m *dota.CSVCMsg_PacketEntities) error 
 		// from Alice. An alternate implementation from Yasha has the same result.
 		delta := r.readUBitVar()
 		index += int32(delta) + 1
-		_debugfl(5, "index delta is %d to %d", delta, index)
 
 		// Read the type of update based on two booleans.
 		// This appears to be backwards from source 1:
@@ -147,8 +148,6 @@ func (p *Parser) onCSVCMsg_PacketEntities(m *dota.CSVCMsg_PacketEntities) error 
 				eventType = EntityEventType_Update
 			}
 		}
-
-		_debugfl(5, "update type is %d, %v", eventType, index)
 
 		// Proceed based on the update type
 		switch eventType {

--- a/property.go
+++ b/property.go
@@ -96,20 +96,21 @@ func (p *Properties) readProperties(r *Reader, ser *dt) {
 
 	// iterate all the fields and set their corresponding values
 	for _, f := range fieldPath.fields {
-		_debugfl(6, "Decoding field %d %s %s %s", r.pos, f.Name, f.Field.Type, f.Field.Encoder)
-		// r.dumpBits(1)
+		if v(6) {
+			_debugf("decoding pos=%d name=%s type=%s encoder=%d", r.pos, f.Name, f.Field.Type, f.Field.Encoder)
+		}
 
 		if f.Field.Serializer.DecodeContainer != nil {
-			_debugfl(6, "Decoding container %v", f.Field.Name)
 			p.KV[f.Name] = f.Field.Serializer.DecodeContainer(r, f.Field)
 		} else if f.Field.Serializer.Decode == nil {
 			p.KV[f.Name] = r.readVarUint32()
-			_debugfl(6, "Decoded default: %d %s %s %v", r.pos, f.Name, f.Field.Type, p.KV[f.Name])
 			continue
 		} else {
 			p.KV[f.Name] = f.Field.Serializer.Decode(r, f.Field)
 		}
 
-		_debugfl(6, "Decoded: %d %s %s %v", r.pos, f.Name, f.Field.Type, p.KV[f.Name])
+		if v(6) {
+			_debugf("decoding pos=%d name=%s type=%s value=%v", r.pos, f.Name, f.Field.Type, p.KV[f.Name])
+		}
 	}
 }

--- a/property.go
+++ b/property.go
@@ -1,13 +1,5 @@
 package manta
 
-var huf HuffmanTree
-
-func init() {
-	if huf == nil {
-		huf = newFieldpathHuffman()
-	}
-}
-
 // Properties is an instance of a set of properties containing key-value data.
 type Properties struct {
 	KV map[string]interface{}
@@ -97,7 +89,7 @@ func (p *Properties) FetchString(k string) (string, bool) {
 // Reads properties into p using the given reader and serializer.
 func (p *Properties) readProperties(r *Reader, ser *dt) {
 	// Create fieldpath
-	fieldPath := newFieldpath(ser, &huf)
+	fieldPath := newFieldpath(ser)
 
 	// Get a list of the included fields
 	fieldPath.walk(r)

--- a/property_decoder.go
+++ b/property_decoder.go
@@ -2,7 +2,6 @@ package manta
 
 import (
 	"math"
-	"strconv"
 	"sync"
 )
 
@@ -88,15 +87,6 @@ func decodeQuantized(r *Reader, f *dt_field) interface{} {
 	}
 	q := qMap[f]
 	qMu.Unlock()
-
-	// Decode value
-	_debugf(
-		"Bitcount: %v, Low: %v, High: %v, Flags: %v",
-		q.Bitcount,
-		q.Low,
-		q.High,
-		strconv.FormatInt(int64(q.Flags), 2),
-	)
 
 	return q.Decode(r)
 }
@@ -189,14 +179,6 @@ func decodeQAngle(r *Reader, f *dt_field) interface{} {
 }
 
 func decodeComponent(r *Reader, f *dt_field) interface{} {
-	_debugf(
-		"Bitcount: %v, Low: %v, High: %v, Flags: %v",
-		saveReturnInt32(f.BitCount),
-		saveReturnFloat32(f.LowValue, "nil"),
-		saveReturnFloat32(f.HighValue, "nil"),
-		strconv.FormatInt(int64(saveReturnInt32(f.Flags)), 2),
-	)
-
 	return r.readBits(1)
 }
 

--- a/property_serializers.go
+++ b/property_serializers.go
@@ -127,7 +127,9 @@ func (pst *PropertySerializerTable) GetPropertySerializerByName(name string) *Pr
 				_panicf("Unable to read vector type for %s", name)
 			}
 		default:
-			//_debugf("No decoder for type %s", name)
+			if v(6) {
+				_debugf("no decoder for type %s", name)
+			}
 		}
 	}
 

--- a/property_test.go
+++ b/property_test.go
@@ -290,14 +290,6 @@ func TestReadProperties(t *testing.T) {
 			continue
 		}
 
-		// Optionally disable debugging
-		debugMode = s.debug
-		if debugMode {
-			debugLevel = 10
-		} else {
-			debugLevel = 0
-		}
-
 		// Read properties
 		r := NewReader(buf)
 		props := NewProperties()

--- a/quantizedfloat.go
+++ b/quantizedfloat.go
@@ -213,7 +213,6 @@ func InitQFD(f *dt_field) *QuantizedFloatDecoder {
 		}
 
 		if bc > qfd.Bitcount {
-			_debugf("Upping bitcount for qf_encode_integers field %v -> %v", qfd.Bitcount, bc)
 			qfd.Bitcount = bc
 			steps = (1 << uint(qfd.Bitcount))
 		}

--- a/reader_util.go
+++ b/reader_util.go
@@ -81,7 +81,7 @@ func (r *Reader) dumpBits(n int) {
 
 			line += _sprintf(" | %s: %s", d.name, colorFn(val))
 		}
-		_debugfl(10, line)
+		_debugf(line)
 	}
 	r.pos = o
 }

--- a/string_table.go
+++ b/string_table.go
@@ -128,7 +128,9 @@ func (p *Parser) onCSVCMsg_UpdateStringTable(m *dota.CSVCMsg_UpdateStringTable) 
 		_panicf("missing string table %d", m.GetTableId())
 	}
 
-	_tracef("tick=%d name=%s changedEntries=%d buflen=%d", p.Tick, t.name, m.GetNumChangedEntries(), len(m.GetStringData()))
+	if v(5) {
+		_debugf("tick=%d name=%s changedEntries=%d size=%d", p.Tick, t.name, m.GetNumChangedEntries(), len(m.GetStringData()))
+	}
 
 	// Parse the updates out of the string table data
 	items := parseStringTable(m.GetStringData(), m.GetNumChangedEntries(), t.userDataFixedSize, t.userDataSize)
@@ -137,17 +139,13 @@ func (p *Parser) onCSVCMsg_UpdateStringTable(m *dota.CSVCMsg_UpdateStringTable) 
 	for _, item := range items {
 		index := item.Index
 		if _, ok := t.Items[index]; ok {
-			// XXX TODO: Sometimes ActiveModifiers change keys, which is suspicous...
 			if item.Key != "" && item.Key != t.Items[index].Key {
-				_tracef("tick=%d name=%s index=%d key='%s' update key -> %s", p.Tick, t.name, index, t.Items[index].Key, item.Key)
 				t.Items[index].Key = item.Key
 			}
 			if len(item.Value) > 0 {
-				_tracef("tick=%d name=%s index=%d key='%s' update value len %d -> %d", p.Tick, t.name, index, t.Items[index].Key, len(t.Items[index].Value), len(item.Value))
 				t.Items[index].Value = item.Value
 			}
 		} else {
-			_tracef("tick=%d name=%s inserting new item %d key '%s'", p.Tick, t.name, index, item.Key)
 			t.Items[index] = item
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -14,24 +14,19 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-var debugMode, traceMode, fixturesMode bool
-var debugLevel, testLevel uint // Test level refers to the inline-test level which runs additional checks on the data
+var debugLevel uint
 
 func init() {
 	if os.Getenv("DEBUG") != "" {
-		debugMode = true
+		debugLevel = 1
 	}
 	if os.Getenv("TRACE") != "" {
-		traceMode = true
-	}
-	if os.Getenv("FIXTURES") != "" {
-		fixturesMode = true
+		debugLevel = 10
 	}
 }
 
 var (
 	_sprintf = fmt.Sprintf
-	_sdump   = spew.Sdump
 )
 
 // Convert a string to an int32
@@ -43,25 +38,14 @@ func atoi32(s string) (int32, error) {
 	return int32(n), nil
 }
 
-// printf with debug level
-func _debugfl(level uint, format string, args ...interface{}) {
-	if level <= debugLevel {
-		args = append([]interface{}{_caller(2)}, args...)
-		fmt.Printf("%s: "+format+"\n", args...)
-	}
+// debugging level check
+func v(level uint) bool {
+	return level <= debugLevel
 }
 
 // printf only if debugging
 func _debugf(format string, args ...interface{}) {
-	if debugMode {
-		args = append([]interface{}{_caller(2)}, args...)
-		fmt.Printf("%s: "+format+"\n", args...)
-	}
-}
-
-// printf only if tracing
-func _tracef(format string, args ...interface{}) {
-	if traceMode {
+	if v(1) {
 		args = append([]interface{}{_caller(2)}, args...)
 		fmt.Printf("%s: "+format+"\n", args...)
 	}
@@ -77,12 +61,10 @@ func _panicf(format string, args ...interface{}) {
 	panic(fmt.Errorf(format, args...))
 }
 
-// dump named object only if debugging
+// dump named object
 func _dump(label string, args ...interface{}) {
-	if debugMode {
-		fmt.Printf("%s: %s", _caller(2), label)
-		spew.Dump(args...)
-	}
+	fmt.Printf("%s: %s", _caller(2), label)
+	spew.Dump(args...)
 }
 
 // dumps a given byte buffer to the given fixture filename


### PR DESCRIPTION
Mostly reducing allocations and significantly reducing the cost of debugging code:

Reduce huffman allocs:
```
BenchmarkMatch2159568145-OLD 1 11252662856 ns/op 2506655376 B/op 141053247 allocs/op
BenchmarkMatch2159568145-NEW 1  9462694535 ns/op 1921834416 B/op 101196564 allocs/op
                                16%              23%             28%
```

Plus reducing debugging allocs/perf:
```
BenchmarkMatch2159568145-OLD 1 11252662856 ns/op 2506655376 B/op 141053247 allocs/op
BenchmarkMatch2159568145-NEW 1  6145306623 ns/op 1172274816 B/op 35949053 allocs/op
                                45%              53%             74%
```

Test suite runtimes:
```
master    85.206s
perf      46.382s
````
