### PR TITLE
Optimize slice allocations

### DIFF
--- a/demo_packet.go
+++ b/demo_packet.go
@@ -62,7 +62,7 @@ func (ms pendingMessages) Less(i, j int) bool {
 func (p *Parser) onCDemoPacket(m *dota.CDemoPacket) error {
 	// Create a slice to store pending mesages. Messages are read first as
 	// pending messages then sorted before dispatch.
-	ms := make(pendingMessages, 0, 10)
+	ms := make(pendingMessages, 0, 2)
 
 	// Read all messages from the buffer. Messages are packed serially as
 	// {type, size, data}. We keep reading until until less than a byte remains.

--- a/demo_packet.go
+++ b/demo_packet.go
@@ -62,7 +62,7 @@ func (ms pendingMessages) Less(i, j int) bool {
 func (p *Parser) onCDemoPacket(m *dota.CDemoPacket) error {
 	// Create a slice to store pending mesages. Messages are read first as
 	// pending messages then sorted before dispatch.
-	ms := make(pendingMessages, 0)
+	ms := make(pendingMessages, 0, 10)
 
 	// Read all messages from the buffer. Messages are packed serially as
 	// {type, size, data}. We keep reading until until less than a byte remains.

--- a/fieldpath.go
+++ b/fieldpath.go
@@ -78,10 +78,11 @@ var fieldpathLookup = []fieldpathOp{
 func newFieldpath(parentTbl *dt) *fieldpath {
 	fp := &fieldpath{
 		parent:   parentTbl,
-		fields:   []*fieldpathField{},
-		index:    []int32{-1}, // always start at -1
+		fields:   make([]*fieldpathField, 0, 2),
+		index:    make([]int32, 1, 2),
 		finished: false,
 	}
+	fp.index[0] = -1 // always start at -1
 
 	return fp
 }

--- a/util.go
+++ b/util.go
@@ -50,6 +50,11 @@ func _debugf(format string, args ...interface{}) {
 	}
 }
 
+func _printf(format string, args ...interface{}) {
+	args = append([]interface{}{_caller(2)}, args...)
+	fmt.Printf("%s: "+format+"\n", args...)
+}
+
 // error with printf syntax
 func _errorf(format string, args ...interface{}) error {
 	return fmt.Errorf(format, args...)


### PR DESCRIPTION
Minor improvement:

```
before:       	       1	5199210575 ns/op	1129681752 B/op	35614364 allocs/op
after:         	       1	5251477791 ns/op	1106652240 B/op	32101761 allocs/op
```