### PR TITLE
Wrong protobuf message for EDotaUserMessages_DOTA_UM_MatchMetadata

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -203,7 +203,7 @@ type Callbacks struct {
 	onCMsgDOTACombatLogEntry                  []func(*dota.CMsgDOTACombatLogEntry) error
 	onCDOTAUserMsg_XPAlert                    []func(*dota.CDOTAUserMsg_XPAlert) error
 	onCDOTAUserMsg_UpdateQuestProgress        []func(*dota.CDOTAUserMsg_UpdateQuestProgress) error
-	onCDOTAClientMsg_MatchMetadata            []func(*dota.CDOTAClientMsg_MatchMetadata) error
+	onCDOTAMatchMetadataFile                  []func(*dota.CDOTAMatchMetadataFile) error
 	onCDOTAUserMsg_QuestStatus                []func(*dota.CDOTAUserMsg_QuestStatus) error
 
 	pb *proto.Buffer
@@ -1195,9 +1195,9 @@ func (c *Callbacks) OnCDOTAUserMsg_UpdateQuestProgress(fn func(*dota.CDOTAUserMs
 	c.onCDOTAUserMsg_UpdateQuestProgress = append(c.onCDOTAUserMsg_UpdateQuestProgress, fn)
 }
 
-// OnCDOTAClientMsg_MatchMetadata registers a callback for EDotaUserMessages_DOTA_UM_MatchMetadata
-func (c *Callbacks) OnCDOTAClientMsg_MatchMetadata(fn func(*dota.CDOTAClientMsg_MatchMetadata) error) {
-	c.onCDOTAClientMsg_MatchMetadata = append(c.onCDOTAClientMsg_MatchMetadata, fn)
+// OnCDOTAMatchMetadataFile registers a callback for EDotaUserMessages_DOTA_UM_MatchMetadata
+func (c *Callbacks) OnCDOTAMatchMetadataFile(fn func(*dota.CDOTAMatchMetadataFile) error) {
+	c.onCDOTAMatchMetadataFile = append(c.onCDOTAMatchMetadataFile, fn)
 }
 
 // OnCDOTAUserMsg_QuestStatus registers a callback for EDotaUserMessages_DOTA_UM_QuestStatus
@@ -4943,17 +4943,17 @@ func (c *Callbacks) callByPacketType(t int32, buf []byte) error {
 		return nil
 
 	case 557: // dota.EDotaUserMessages_DOTA_UM_MatchMetadata
-		if c.onCDOTAClientMsg_MatchMetadata == nil {
+		if c.onCDOTAMatchMetadataFile == nil {
 			return nil
 		}
 
-		msg := &dota.CDOTAClientMsg_MatchMetadata{}
+		msg := &dota.CDOTAMatchMetadataFile{}
 		c.pb.SetBuf(buf)
 		if err := c.pb.Unmarshal(msg); err != nil {
 			return err
 		}
 
-		for _, fn := range c.onCDOTAClientMsg_MatchMetadata {
+		for _, fn := range c.onCDOTAMatchMetadataFile {
 			if err := fn(msg); err != nil {
 				return err
 			}

--- a/gen/callbacks.go
+++ b/gen/callbacks.go
@@ -163,7 +163,7 @@ var messageTypes = []*dotaMessage{
 			case "EDotaUserMessages_DOTA_UM_CombatLogDataHLTV":
 				return "CMsgDOTACombatLogEntry", true
 			case "EDotaUserMessages_DOTA_UM_MatchMetadata":
-				return "CDOTAClientMsg_MatchMetadata", true
+				return "CDOTAMatchMetadataFile", true
 			case "EDotaUserMessages_DOTA_UM_MatchDetails":
 				return "", false
 			}


### PR DESCRIPTION
Packet type `EDotaUserMessages_DOTA_UM_MatchMetadata` (557) has the wrong associated protobuf message type, currently it's `CDOTAClientMsg_MatchMetadata` but it should be `CDOTAMatchMetadataFile`.

When testing some of the callbacks, I registered a callback with `OnCDOTAClientMsg_MatchMetadata` and the parser returns a protobuf error when deserializing the protobuf message (wrong wire types for message fields). Changing the parser to deserialize the message into a `CDOTAMatchMetadataFile` seems to work.

Tests don't seem to cover this callback, but testing locally with a recent demo works.