### PR TITLE
Outlanders patch: read m_flRuneTime as a 4-bit float

### DIFF
--- a/field_decoder.go
+++ b/field_decoder.go
@@ -62,6 +62,8 @@ func floatFactory(f *field) fieldDecoder {
 		return floatCoordDecoder
 	case "simtime":
 		return simulationTimeDecoder
+	case "runetime":
+		return runeTimeDecoder
 	}
 
 	if f.bitCount == nil || (*f.bitCount <= 0 || *f.bitCount >= 32) {
@@ -129,6 +131,10 @@ func floatCoordDecoder(r *reader) interface{} {
 
 func noscaleDecoder(r *reader) interface{} {
 	return math.Float32frombits(r.readBits(32))
+}
+
+func runeTimeDecoder(r *reader) interface{} {
+	return math.Float32frombits(r.readBits(4))
 }
 
 func simulationTimeDecoder(r *reader) interface{} {

--- a/field_patch.go
+++ b/field_patch.go
@@ -72,6 +72,8 @@ var fieldPatches = []fieldPatch{
 		switch f.varName {
 		case "m_flSimulationTime", "m_flAnimTime":
 			f.encoder = "simtime"
+		case "m_flRuneTime":
+			f.encoder = "runetime"
 		}
 	}},
 }

--- a/manta_test.go
+++ b/manta_test.go
@@ -13,6 +13,8 @@ func BenchmarkMatch2159568145(b *testing.B) { testScenarios[2159568145].bench(b)
 // Test client
 func TestMatch6682694(t *testing.T) { testScenarios[6682694].test(t) }
 
+func TestMatch5129306977(t *testing.T) { testScenarios[5129306977].test(t) }
+func TestMatch5129281647(t *testing.T) { testScenarios[5129281647].test(t) }
 func TestMatch4259518439(t *testing.T) { testScenarios[4259518439].test(t) }
 func TestMatch4257655794(t *testing.T) { testScenarios[4257655794].test(t) }
 func TestMatch3949386909(t *testing.T) { testScenarios[3949386909].test(t) }
@@ -68,6 +70,26 @@ type testScenario struct {
 }
 
 var testScenarios = map[int64]testScenario{
+	5129306977: {
+		matchId:                  "5129306977",
+		replayUrl:                "https://s3-us-west-2.amazonaws.com/manta.dotabuff/5129306977.dem",
+		expectGameBuild:          3846,
+		expectEntityEvents:       2466090,
+		expectUnitOrderEvents:    36185,
+		expectHeroEntityName:     "CDOTA_Unit_Hero_Warlock",
+		expectHeroEntityMana:     2582.94,
+		expectHeroEntityPlayerId: 8,
+	},
+	5129281647: {
+		matchId:                  "5129281647",
+		replayUrl:                "https://s3-us-west-2.amazonaws.com/manta.dotabuff/5129281647.dem",
+		expectGameBuild:          3846,
+		expectEntityEvents:       2919107,
+		expectUnitOrderEvents:    43538,
+		expectHeroEntityName:     "CDOTA_Unit_Hero_Pudge",
+		expectHeroEntityMana:     1647.9391,
+		expectHeroEntityPlayerId: 8,
+	},
 	4259518439: {
 		matchId:                  "4259518439",
 		replayUrl:                "https://s3-us-west-2.amazonaws.com/manta.dotabuff/4259518439.dem",

--- a/parser_test.go
+++ b/parser_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -13,6 +14,10 @@ import (
 )
 
 func TestStreamingReaderTimeout(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping test in CI environment")
+	}
+
 	assert := assert.New(t)
 
 	// create a http client with a timeout too low to get the entire replay


### PR DESCRIPTION
We're currently trying to read the `m_flRuneTime` as a quantized float and the params (`minTime`, `maxTime`) look like garbage. This changes manta to simply read this property as a 4-bit float (which always seems to be zero), at least allowing us to get through the replays.