### PR TITLE
Fixed relative StringTables indexes

### DIFF
--- a/string_table.go
+++ b/string_table.go
@@ -201,14 +201,12 @@ func parseStringTable(buf []byte, numUpdates int32, name string, userDataFixed b
 		value := []byte{}
 
 		// Read a boolean to determine whether the operation is an increment or
-		// has a fixed index position. A fixed index position of zero should be
+		// has a relative index position. A fixed index position of zero should be
 		// the last data in the buffer, and indicates that all data has been read.
-		incr := r.readBoolean()
-		if incr {
-			index++
-		} else {
-			index = int32(r.readVarUint32()) + 1
+		if !r.readBoolean() {
+			index += int32(r.readVarUint32()) + 1
 		}
+		index++
 
 		// Some values have keys, some don't.
 		hasKey := r.readBoolean()


### PR DESCRIPTION
AFAIK they're not used at CSVCMsg_CreateStringTable, but they're used at almost every CSVCMsg_UpdateStringTable.
I noticed this issue when I've tried to parse modifiers (CDOTAModifierBuffTableEntry) out of ActiveModifiers table - there were wrong list of them.
Things that helped this fix to land:
`dumpstringtable ActiveModifiers cl verbose`
`cl_dota_dump_modifier_stringtable`
debug macos dota binaries (first call of bf_write::WriteVarInt32 inside CNetworkStringTable::WriteUpdate)