### PR TITLE
Increase max fieldPath length

### DIFF
--- a/field_path.go
+++ b/field_path.go
@@ -284,14 +284,14 @@ func newFieldPath() *fieldPath {
 var fpPool = &sync.Pool{
 	New: func() interface{} {
 		return &fieldPath{
-			path: make([]int, 6),
+			path: make([]int, 7),
 			last: 0,
 			done: false,
 		}
 	},
 }
 
-var fpReset = []int{-1, 0, 0, 0, 0, 0}
+var fpReset = []int{-1, 0, 0, 0, 0, 0, 0}
 
 // reset resets the fieldPath to the empty value
 func (fp *fieldPath) reset() {

--- a/manta_test.go
+++ b/manta_test.go
@@ -11,6 +11,7 @@ import (
 func BenchmarkMatch2159568145(b *testing.B) { testScenarios[2159568145].bench(b) }
 
 // Test client
+func TestMatchNew6792460214(t *testing.T) { testScenarios[6792460214].test(t) }
 func TestMatchNew6492864631(t *testing.T) { testScenarios[6492864631].test(t) }
 func TestMatchNew6320800962(t *testing.T) { testScenarios[6320800962].test(t) }
 func TestMatchNew5747195393(t *testing.T) { testScenarios[5747195393].test(t) }
@@ -74,6 +75,13 @@ type testScenario struct {
 }
 
 var testScenarios = map[int64]testScenario{
+	6792460214: {
+		matchId:               "6792460214",
+		replayUrl:             "https://s3-us-west-2.amazonaws.com/manta.dotabuff/6792460214.dem",
+		expectGameBuild:       5469,
+		expectEntityEvents:    1703858,
+		expectUnitOrderEvents: 58720,
+	},
 	6492864631: {
 		matchId:               "6492864631",
 		replayUrl:             "https://s3-us-west-2.amazonaws.com/manta.dotabuff/6492864631.dem",


### PR DESCRIPTION
Fix for new replays which are causing fieldPath out-of-bounds errors.