### PR TITLE
feat: add missing 7.36 decoders

### DIFF
--- a/field_decoder.go
+++ b/field_decoder.go
@@ -34,7 +34,9 @@ var fieldTypeDecoders = map[string]fieldDecoder{
 	"uint32":  unsignedDecoder,
 	"uint8":   unsignedDecoder,
 
-	"GameTime_t": noscaleDecoder,
+	"GameTime_t":     noscaleDecoder,
+	"HeroFacetKey_t": unsigned64Decoder,
+	"BloodType":      unsignedDecoder,
 
 	"CBodyComponent":       componentDecoder,
 	"CGameSceneNodeHandle": unsignedDecoder,


### PR DESCRIPTION
Since patch 7.36 was released, we've been experiencing the same intermittent issues as mentioned in #157,  #158 & #159.

The issue `unable to find existing entity [integer]` was [fixed in Clarity](https://github.com/skadistats/clarity/commit/75e4122776c5f2abc7ee71842cea484f9258cc27), and it would be nice to get manta up-to-speed.