### PR TITLE
Add OnModifierTableEntry event handler

### DIFF
--- a/modifier.go
+++ b/modifier.go
@@ -1,0 +1,34 @@
+package manta
+
+import (
+	"github.com/dotabuff/manta/dota"
+	"github.com/golang/protobuf/proto"
+)
+
+type ModifierTableEntryHandler func(msg *dota.CDOTAModifierBuffTableEntry) error
+
+// OnModifierTableEntry registers a handler for when a ModifierBuffTableEntry
+// is created or updated.
+func (p *Parser) OnModifierTableEntry(fn ModifierTableEntryHandler) {
+	p.modifierTableEntryHandlers = append(p.modifierTableEntryHandlers, fn)
+}
+
+// emitModifierTableEvents emits ModifierBuffTableEntry events
+// from the given string table items.
+func (p *Parser) emitModifierTableEvents(items []*stringTableItem) error {
+	for _, item := range items {
+		msg := &dota.CDOTAModifierBuffTableEntry{}
+		if err := proto.NewBuffer(item.Value).Unmarshal(msg); err != nil {
+			_debugf("unable to unmarshal ModifierBuffTableEntry: %s", err)
+			continue
+		}
+
+		for _, fn := range p.modifierTableEntryHandlers {
+			if err := fn(msg); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/parser.go
+++ b/parser.go
@@ -31,22 +31,23 @@ type Parser struct {
 	// AfterStopCallback is a function to be called when the parser stops.
 	AfterStopCallback func()
 
-	classBaselines    map[int32][]byte
-	classesById       map[int32]*class
-	classesByName     map[string]*class
-	classIdSize       uint32
-	classInfo         bool
-	entities          map[int32]*Entity
-	entityFullPackets int
-	entityHandlers    []EntityHandler
-	gameEventHandlers map[string][]GameEventHandler
-	gameEventNames    map[int32]string
-	gameEventTypes    map[string]*gameEventType
-	isStopping        bool
-	serializers       map[string]*serializer
-	stream            *stream
-	stringTables      *stringTables
-	stopAtTick        uint32
+	classBaselines             map[int32][]byte
+	classesById                map[int32]*class
+	classesByName              map[string]*class
+	classIdSize                uint32
+	classInfo                  bool
+	entities                   map[int32]*Entity
+	entityFullPackets          int
+	entityHandlers             []EntityHandler
+	gameEventHandlers          map[string][]GameEventHandler
+	gameEventNames             map[int32]string
+	gameEventTypes             map[string]*gameEventType
+	isStopping                 bool
+	modifierTableEntryHandlers []ModifierTableEntryHandler
+	serializers                map[string]*serializer
+	stream                     *stream
+	stringTables               *stringTables
+	stopAtTick                 uint32
 }
 
 // Create a new parser from a byte slice.

--- a/string_table.go
+++ b/string_table.go
@@ -121,6 +121,13 @@ func (p *Parser) onCSVCMsg_CreateStringTable(m *dota.CSVCMsg_CreateStringTable) 
 		p.updateInstanceBaseline()
 	}
 
+	// Emit events for modifier table entry updates
+	if t.name == "ActiveModifiers" {
+		if err := p.emitModifierTableEvents(items); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -157,6 +164,13 @@ func (p *Parser) onCSVCMsg_UpdateStringTable(m *dota.CSVCMsg_UpdateStringTable) 
 	// Apply the updates to baseline state
 	if t.name == "instancebaseline" {
 		p.updateInstanceBaseline()
+	}
+
+	// Emit events for modifier table entry updates
+	if t.name == "ActiveModifiers" {
+		if err := p.emitModifierTableEvents(items); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Adds an `OnModifierTableEntry` event handler to the parser which is triggered whenever a `CDOTAModifierBuffTableEntry` is created or updated.